### PR TITLE
Fix getRefresh Token input and Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ It even allows you to generate a JPEG receipt to use in your automation scripts,
 
 ## Get your refresh Token
 You first need to retrieve your refreshToken. This can be done with the nodeJS script getLidlRefreshToken.js. You might need to install
-additional node JS libraries first with npm (e.g. request or openid-client).
+additional node JS libraries first with npm (e.g. request or openid-client, puppeteer).
+```bash
+npm install puppeteer openid-client
+```
 Run the script and enter the country and language with the country you are using your account with.
 
 ## How to use

--- a/src/getLidlRefreshToken.js
+++ b/src/getLidlRefreshToken.js
@@ -17,8 +17,12 @@ const readline = require('readline').createInterface({
     input: process.stdin,
     output: process.stdout
 });
-const util = require('util');
-const question = util.promisify(readline.question).bind(readline);
+
+function question(query) {
+    return new Promise(resolve => {
+        readline.question(query, resolve);
+    })
+}
 
 Issuer.discover('https://accounts.lidl.com')
     .then(function (openidIssuer) {


### PR DESCRIPTION
Add code snippet in Readme which packages need to be installed with npm.

Remove one line of code in getRefreshToken script as the constant was unused.

Change constants to read in user input from keyboard, was not working properly with the promises provided.